### PR TITLE
fix: three security vulnerabilities in Go and TypeScript verifiers

### DIFF
--- a/go/shared/merkle/merkle.go
+++ b/go/shared/merkle/merkle.go
@@ -8,6 +8,7 @@ package merkle
 
 import (
 	"crypto/sha256"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 )
@@ -145,10 +146,9 @@ func VerifyInclusion(entryHash []byte, entryIndex, treeSize int, proof [][]byte,
 		size = (size + 1) / 2
 	}
 
-	computed := fmt.Sprintf("%x", node)
-	expected := fmt.Sprintf("%x", expectedRoot)
-	if computed != expected {
-		return fmt.Errorf("merkle: root mismatch: computed %s, expected %s", computed, expected)
+	// subtle.ConstantTimeCompare prevents timing side-channels on the root hash.
+	if subtle.ConstantTimeCompare(node, expectedRoot) != 1 {
+		return fmt.Errorf("merkle: root mismatch: computed %x, expected %x", node, expectedRoot)
 	}
 	return nil
 }

--- a/go/verifier/main.go
+++ b/go/verifier/main.go
@@ -166,6 +166,12 @@ func loadTrustConfigFromBytes(body []byte) error {
 		copy(kid[:], kidBytes)
 		witnesses[i] = verify.WitnessEntry{Name: wc.Name, KeyID: kid, PubKey: pubBytes}
 	}
+	if tc.WitnessQuorum < 1 {
+		return fmt.Errorf("witness_quorum must be >= 1, got %d", tc.WitnessQuorum)
+	}
+	if tc.WitnessQuorum > len(witnesses) {
+		return fmt.Errorf("witness_quorum (%d) exceeds witness count (%d)", tc.WitnessQuorum, len(witnesses))
+	}
 	v.AddAnchor(&verify.TrustAnchor{
 		Origin: tc.Origin, OriginID: originIDInt, IssuerPubKey: issuerPubBytes,
 		IssuerKeyName: tc.IssuerKeyName,

--- a/go/verifier/verify/verify.go
+++ b/go/verifier/verify/verify.go
@@ -68,18 +68,22 @@ type Result struct {
 	SchemaID     uint64         `json:"schema_id"`
 }
 
+const maxCacheEntries = 1000
+
 // Verifier holds trust anchors and a checkpoint cache.
 type Verifier struct {
-	mu      sync.RWMutex
-	anchors map[uint64]*TrustAnchor
-	cache   map[string]*CachedCheckpoint
+	mu         sync.RWMutex
+	anchors    map[uint64]*TrustAnchor
+	cache      map[string]*CachedCheckpoint
+	cacheOrder []string // insertion order for LRU eviction
 }
 
 // New creates an empty Verifier.
 func New() *Verifier {
 	return &Verifier{
-		anchors: make(map[uint64]*TrustAnchor),
-		cache:   make(map[string]*CachedCheckpoint),
+		anchors:    make(map[uint64]*TrustAnchor),
+		cache:      make(map[string]*CachedCheckpoint),
+		cacheOrder: make([]string, 0, maxCacheEntries+1),
 	}
 }
 
@@ -180,6 +184,13 @@ func (v *Verifier) Verify(payloadBytes []byte) *Result {
 			anchor.WitnessQuorum, anchor.WitnessQuorum, fetchedSize))
 		rootHash = fetchedRoot
 		v.mu.Lock()
+		if _, exists := v.cache[cacheKey]; !exists {
+			if len(v.cacheOrder) >= maxCacheEntries {
+				delete(v.cache, v.cacheOrder[0])
+				v.cacheOrder = v.cacheOrder[1:]
+			}
+			v.cacheOrder = append(v.cacheOrder, cacheKey)
+		}
 		v.cache[cacheKey] = &CachedCheckpoint{TreeSize: fetchedSize, RootHash: fetchedRoot, FetchedAt: time.Now()}
 		v.mu.Unlock()
 	}

--- a/ts/shared/merkle.ts
+++ b/ts/shared/merkle.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "crypto";
 /**
  * RFC 6962 §2.1 Merkle tree operations for MTA-QR.
  * Leaf hashes: SHA-256(0x00 || data)
@@ -109,10 +110,11 @@ export function verifyInclusion(
     size = Math.floor((size + 1) / 2);
   }
 
-  const computed = Buffer.from(node).toString("hex");
-  const expected = Buffer.from(expectedRoot).toString("hex");
-  if (computed !== expected) {
-    throw new Error(`merkle: root mismatch: computed ${computed}, expected ${expected}`);
+  // timingSafeEqual prevents timing side-channels on the root hash comparison.
+  if (!timingSafeEqual(Buffer.from(node), Buffer.from(expectedRoot))) {
+    throw new Error(
+      `merkle: root mismatch: computed ${Buffer.from(node).toString("hex")},` +
+      ` expected ${Buffer.from(expectedRoot).toString("hex")}`);
   }
 }
 

--- a/ts/verifier/main.ts
+++ b/ts/verifier/main.ts
@@ -28,6 +28,8 @@ interface TrustAnchor {
 const anchors = new Map<string, TrustAnchor>(); // keyed by origin_id hex
 
 // Checkpoint cache: "origin:treeSize" → rootHash
+// Bounded to prevent memory exhaustion from payloads with incrementing tree_size.
+const MAX_CACHE_ENTRIES = 1000;
 const checkpointCache = new Map<string, { rootHash: Uint8Array; fetchedAt: number }>();
 
 // --- Verification ---
@@ -104,6 +106,9 @@ async function verify(payloadBytes: Uint8Array): Promise<VerifyResult> {
     add("Checkpoint fetch+verify", true,
       `issuer sig ✓ · ${anchor.witnessQuorum}/${anchor.witnessQuorum} witnesses ✓ · tree_size=${fetchedSize}`);
     rootHash = fetchedRoot;
+    if (checkpointCache.size >= MAX_CACHE_ENTRIES) {
+      checkpointCache.delete(checkpointCache.keys().next().value!);
+    }
     checkpointCache.set(cacheKey, { rootHash: fetchedRoot, fetchedAt: Date.now() });
   }
 
@@ -296,10 +301,18 @@ const server = createServer(async (req, res) => {
       keyID: new Uint8Array(Buffer.from(w.key_id_hex, "hex")),
       pubKey: new Uint8Array(Buffer.from(w.pub_key_hex, "hex")),
     }));
+    const witnessQuorum = tc.witness_quorum;
+    if (!Number.isInteger(witnessQuorum) || witnessQuorum < 1) {
+      return json(res, { ok: false, error: `witness_quorum must be >= 1, got ${witnessQuorum}` }, 400);
+    }
+    if (witnessQuorum > witnesses.length) {
+      return json(res, { ok: false,
+        error: `witness_quorum (${witnessQuorum}) exceeds witness count (${witnesses.length})` }, 400);
+    }
     const anchor: TrustAnchor = {
       origin: tc.origin, originID: oid, issuerPubKey,
       issuerKeyName: tc.issuer_key_name ?? "",
-      sigAlg: tc.sig_alg, witnessQuorum: tc.witness_quorum,
+      sigAlg: tc.sig_alg, witnessQuorum,
       witnesses, checkpointURL: tc.checkpoint_url,
     };
     anchors.set(oid.toString(16).padStart(16, "0"), anchor);


### PR DESCRIPTION
## Security fixes

This PR addresses three vulnerabilities identified in the internal security review of March 2026.

### MTA-2026-01 [HIGH] — Witness quorum bypass

Both `go/verifier/main.go` and `ts/verifier/main.ts` stored `witness_quorum` from a trust config JSON without validation. A trust config with `witness_quorum=0` was accepted, and the subsequent check (`verified_count < quorum`) evaluates to `false` for any non-negative count — bypassing all cosignature verification entirely. An attacker who can cause the verifier to load a malicious trust config can disable witness verification for that anchor.

**Fix:** Validate `witness_quorum >= 1` and `witness_quorum <= len(witnesses)` immediately after parsing, before registering the anchor.

### MTA-2026-02 [MEDIUM] — Variable-time Merkle root comparison

Both verifiers compared the computed Merkle root against the expected root by converting to hex strings and using `!=` / `!==`, which short-circuits at the first differing byte.

**Fix:** `subtle.ConstantTimeCompare` (Go), `crypto.timingSafeEqual` (TypeScript).

### MTA-2026-03 [LOW] — Unbounded checkpoint cache

The checkpoint cache (keyed by `origin:treeSize`) had no size limit. Payloads with rapidly incrementing `tree_size` values could exhaust heap memory.

**Fix:** Cap at 1,000 entries with insertion-order eviction in both languages.

### MTA-2026-04 [INFO] — Trailing bytes already correct

Trailing byte rejection was already correctly implemented in both Go and TypeScript. No change required.

---

## Files changed

| File | Change |
|------|--------|
| `go/shared/merkle/merkle.go` | Constant-time comparison (MTA-2026-02) |
| `go/verifier/main.go` | Quorum validation at load time (MTA-2026-01) |
| `go/verifier/verify/verify.go` | Bounded cache with eviction (MTA-2026-03) |
| `ts/shared/merkle.ts` | Constant-time comparison (MTA-2026-02) |
| `ts/verifier/main.ts` | Quorum validation + bounded cache (MTA-2026-01 + MTA-2026-03) |

## Testing

- `go build ./...` — clean
- `go test ./...` — all pass
- `npx tsc --noEmit` — clean
- TS signing tests: 5/5 pass
- TS vector tests: 5/5 pass

No behaviour change for valid trust configurations and valid payloads.