### PR TITLE
docs: update ARCHITECTURE, SPEC, and README for four-language reality

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,11 +6,13 @@ This document describes the code structure of `mta-qr-demo`, the design decision
 
 ## Overview
 
-The repository contains eight services (six issuers + two verifiers) sharing a common protocol layer:
+The repository contains two layers: HTTP services (Go and TypeScript) for running live issuers and verifiers, and standalone SDK libraries (Go, TypeScript, Rust, Java) that implement the full protocol without an HTTP layer.
+
+### HTTP services
 
 ```
                         test-vectors/vectors.json
-                        browser-demo/index.html  ← standalone browser implementation
+                        browser-demo/  ← browser demo (built from ts/sdk/)
                                │
               ┌────────────────┴────────────────┐
               │                                 │
@@ -26,11 +28,28 @@ go/issuer (×3)      go/verifier  ts/issuer (×3)      ts/verifier
 :8085 ML-DSA-44                   :3005 ML-DSA-44
 ```
 
-The two shared libraries are independently implemented and independently tested against the same canonical fixtures. The interop test then confirms that any payload produced by any issuer verifies correctly with any verifier.
+The two shared libraries are independently implemented and tested against the same canonical fixtures. The interop test confirms that any payload produced by any issuer verifies correctly with any verifier.
+
+### SDK libraries
+
+Four standalone libraries implementing the same protocol without HTTP:
+
+| Directory | Language | Issuer | Verifier | Signers |
+|-----------|----------|:------:|:--------:|---------|
+| `ts/sdk/` | TypeScript | ✓ | ✓ | Local (Ed25519, ECDSA P-256, ML-DSA-44), GoodKey |
+| `rust/`   | Rust       | ✓ | ✓ | Local (Ed25519, ECDSA P-256, ML-DSA-44), GoodKey |
+| `java/`   | Java       | ✓ | ✓ | Local (Ed25519, ECDSA P-256, ML-DSA-44), GoodKey |
+| `go/` (SDK portion) | Go | ✓ | ✓ | Local (Ed25519, ECDSA P-256, ML-DSA-44), GoodKey |
+
+The SDKs share no code with the HTTP services. They use injectable signers and note providers, making them suitable for embedded use, testing, and environments without network access. All four pass a 96-cell cross-language interop matrix (4 issuers × 4 verifiers × 3 algorithms × 2 payload modes).
+
+The TypeScript SDK (`ts/sdk/`) also provides a browser bundle entry point (`src/browser-bundle.ts`) compiled by esbuild into `browser-demo/deps/mta_qr_sdk.iife.js`, which the browser demo uses in place of inline protocol code.
 
 ---
 
-## Protocol layer (`go/shared/`, `ts/shared/`)
+## Protocol layer
+
+The Go HTTP service uses `go/shared/`. The TypeScript HTTP service uses `ts/shared/`. The SDK libraries each contain equivalent implementations inline. All implementations are independently derived and verified against the same canonical test vectors.
 
 ### merkle
 
@@ -224,9 +243,15 @@ See [`test-vectors/README.md`](test-vectors/README.md) for the format and how to
 
 Builds Go binaries, starts all services as subprocesses, runs the 12-cell positive matrix (3 algorithms × 4 impl pairs) plus 3 negative tests, prints per-step traces, exits 0 on 15/15.
 
-`browser-demo/index.html` — self-contained single-file browser demo, no build step, no server. Same tiled tree structure and wire format as Go/TS.
+Uses `MTA_PORT`, `MTA_ORIGIN`, and `MTA_SIG_ALG` environment variables to start multiple instances of the same binary with different configurations. Each algorithm variant gets a distinct origin string to avoid checkpoint cache collisions.
 
-Uses `MTA_PORT`, `MTA_ORIGIN`, and `MTA_SIG_ALG` environment variables to start multiple instances of the same binary with different configurations. Each algorithm variant gets a distinct origin string to avoid the checkpoint cache collision.
+**Coverage note:** `interop_test.py` covers only the Go and TypeScript HTTP services. The Rust and Java SDK interop matrix (96 cells: 4 issuers × 4 verifiers × 3 algorithms × 2 modes) runs via `cargo test` and `mvn test` in their respective directories. Extending `interop_test.py` to cover Rust and Java requires wrapping those SDKs in HTTP servers.
+
+### Browser demo (`browser-demo/`)
+
+`browser-demo/index.html` is a self-contained browser implementation built from `browser-demo/index.template.html` by `browser-demo/build.py`. The build script injects three JavaScript bundles — nayuki QR encoder, noble post-quantum, and the MTA-QR SDK (`mta_qr_sdk.iife.js`) — into placeholder comments in the template.
+
+The SDK bundle is compiled from `ts/sdk/src/browser-bundle.ts` by esbuild. CI rebuilds it from source on every push; the committed copy in `browser-demo/deps/` is a convenience snapshot. Both Mode 1 (proof embedded) and Mode 2 (proof deferred) work in-browser for Ed25519 and ML-DSA-44.
 
 ---
 
@@ -273,26 +298,38 @@ These are the only available FIPS 204 implementations for their respective platf
 
 1. **Register a `sig_alg` value** in the spec table (SPEC.md Cryptography section). Requires a C2SP note signature type registration for full interoperability.
 
-2. **Implement in Go** (`go/shared/signing/`):
+2. **Implement in the Go HTTP service** (`go/shared/signing/`):
    - Add a `<alg>.go` file with a struct implementing `signing.Signer`
    - Add the `sig_alg` constant to `signing.go`
    - Add a `case` in `Verify()`, `SigLen()`, `PubKeyLen()`, and `SigAlgName()`
 
-3. **Implement in TypeScript** (`ts/shared/signing.ts`):
+3. **Implement in the TypeScript HTTP service** (`ts/shared/signing.ts`):
    - Add a `SIG_ALG_*` constant
    - Add factory functions (`<alg>FromSeed(...)`, `new<Alg>()`) implementing `Signer`
    - Include a `keyName` field in the returned `Signer` — this is how verifiers identify the issuer's signature line in note format
    - Add a `case` in `verify()`, `sigLen()`, and `sigAlgName()`
 
-4. **Add test vectors** (`test-vectors/vectors.json`):
-   - A `signing-<alg>` vector with: fixed key material, a fixed message (use the checkpoint body from `checkpoint-body-v1`), the expected public key, and for deterministic algorithms the expected signature
-   - For randomized algorithms (ECDSA-family): include a `pre_recorded_sig` produced by the reference implementation for cross-impl verify testing
-   - Both Go and TypeScript test suites must load and pass this vector
+4. **Implement in the TypeScript SDK** (`ts/sdk/src/signers/local.ts`, `ts/sdk/src/verify-sig.ts`):
+   - Add a `local<Alg>()` factory function in `local.ts`
+   - Add a `case` in the `verifySig()` dispatch in `verify-sig.ts`
 
-5. **Add to the issuer** (`go/issuer/main.go`, `ts/issuer/main.ts`):
+5. **Implement in Rust** (`rust/src/signers/local.rs`, `rust/src/signing/verify.rs`):
+   - Add a `LocalSigner::<alg>()` constructor in `local.rs`
+   - Add a `case` in the `verify()` dispatch in `verify.rs`
+
+6. **Implement in Java** (`java/src/main/java/.../signers/LocalSigner.java`, `.../signing/SignatureVerifier.java`):
+   - Add a `LocalSigner.<alg>(byte[] seed)` factory method
+   - Add a `case` in `SignatureVerifier.verify()`
+
+7. **Add test vectors** (`test-vectors/vectors.json`):
+   - A `signing-<alg>` vector with: fixed key material, a fixed message, the expected public key, and for deterministic algorithms the expected signature
+   - For randomized algorithms (ECDSA-family): include a `pre_recorded_sig` produced by the reference implementation for cross-impl verify testing
+   - All four test suites must load and pass this vector
+
+8. **Add to the HTTP service issuers** (`go/issuer/main.go`, `ts/issuer/main.ts`):
    - Add a case in the `MTA_SIG_ALG` env-var switch
 
-6. **Add to the interop matrix** (`interop_test.py`):
+9. **Add to the interop matrix** (`interop_test.py`):
    - Add two service entries (one Go, one TS) with distinct origins encoding the algorithm
    - Add four positive cells (Go→Go, TS→TS, Go→TS, TS→Go)
    - Add to `docker-compose.yml` with `MTA_BASE_URL` set to the container's own service name and port

--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ These are genuine gaps that should be addressed before production use. They are 
 
 **SPEC.md does not describe Mode 2 tile addressing.** The spec covers the payload binary format and trust config schema but does not define the tile server API, tile addressing scheme, or tile verification algorithm needed to complete a Mode 2 deployment.
 
-**Browser demo SDK bundle is not committed.** `browser-demo/deps/mta_qr_sdk.iife.js` is built by CI from `ts/src/browser-bundle.ts` via esbuild and not checked in. If the CI workflow is not yet wired to the GitHub Pages deployment step, the demo may serve a stale bundle.
+**Browser demo SDK bundle is not committed as a source artifact.** `browser-demo/deps/mta_qr_sdk.iife.js` is committed as a convenience snapshot but CI rebuilds it from `ts/sdk/src/browser-bundle.ts` on every push. The committed copy may be slightly stale between pushes; the CI-built version is authoritative.
+
+**`interop_test.py` covers only Go and TypeScript HTTP services.** The Rust and Java SDK interop matrix runs via `cargo test` and `mvn test`. Extending `interop_test.py` to include Rust and Java requires wrapping those SDKs in HTTP server binaries with the same `/issue`, `/verify`, and `/trust-config` endpoints as the existing Go and TypeScript services.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -226,12 +226,12 @@ which key and signature type to use when validating the checkpoint.
 | Value | Algorithm | Sig size | WebCrypto? | Quantum-resistant? | Reference impl |
 |-------|-----------|----------|------------|-------------------|----|
 | 0 | FN-DSA-512 (FIPS 206) | up to 666 bytes, typ. 600–650 | No | Yes | — |
-| 1 | ML-DSA-44 (FIPS 204) | 2,420 bytes (fixed) | No | Yes | ✓ Go + TypeScript |
+| 1 | ML-DSA-44 (FIPS 204) | 2,420 bytes (fixed) | No | Yes | ✓ Go, TypeScript, Rust, Java |
 | 2 | ML-DSA-65 (FIPS 204) | 3,309 bytes (fixed) | No | Yes | — |
 | 3 | SLH-DSA-SHA2-128s (FIPS 205) | 7,856 bytes (fixed) | No | Yes | — |
-| 4 | ECDSA P-256 | 64 bytes (raw r‖s, IEEE P1363) | ✓ Yes | No | ✓ Go + TypeScript |
+| 4 | ECDSA P-256 | 64 bytes (raw r‖s, IEEE P1363) | ✓ Yes | No | ✓ Go, TypeScript, Rust, Java |
 | 5 | ECDSA P-384 | 96 bytes (raw r‖s, IEEE P1363) | ✓ Yes | No | — |
-| 6 | Ed25519 | 64 bytes | ✓ Modern | No | ✓ Go + TypeScript |
+| 6 | Ed25519 | 64 bytes | ✓ Modern | No | ✓ Go, TypeScript, Rust, Java |
 
 Unrecognized `sig_alg` values MUST be rejected.
 
@@ -1071,9 +1071,7 @@ signs independently and the other's verify function MUST accept that signature.
 Before any MTA-QR implementation can use ECDSA P-256, ECDSA P-384, or FN-DSA-512
 for checkpoint signing, a note signature algorithm type must be registered for
 each at C2SP. Ed25519 (`sig_alg=6`) is fully specified and not blocked.
-ML-DSA-44 (`sig_alg=1`) is implemented in this reference (Go via cloudflare/circl;
-TypeScript via @noble/post-quantum) but also requires C2SP note signature registration
-before it can interoperate with standard tlog-checkpoint parsers.
+ML-DSA-44 (`sig_alg=1`) is implemented in all four reference implementations (Go via cloudflare/circl; TypeScript via @noble/post-quantum; Rust via ml-dsa; Java via BouncyCastle 1.79+ MLDSAKeyPairGenerator) but also requires C2SP note signature registration before it can interoperate with standard tlog-checkpoint parsers.
 
 For ECDSA P-256 and P-384, the registration must specify:
 - Note verifier key name format for ECDSA public keys (uncompressed point, base64-encoded)


### PR DESCRIPTION
Updates three documents to reflect that the repo now has four language implementations, not two.

**ARCHITECTURE.md**
- Overview: adds SDK library table (Go, TypeScript, Rust, Java) and explains the two-layer structure (HTTP services + standalone SDKs)
- Adds browser demo build pipeline explanation (build.py, SDK bundle injection)
- Interop test section: documents that `interop_test.py` covers Go+TS only; Rust/Java matrix runs via `cargo test`/`mvn test`; notes the HTTP wrapper requirement to extend coverage
- "Adding a new signing algorithm": expanded from 2-language to 6-step guide covering all four implementations

**SPEC.md**
- Algorithm table: "✓ Go + TypeScript" → "✓ Go, TypeScript, Rust, Java" for all three algorithms
- ML-DSA-44 note: adds Rust (ml-dsa crate) and Java (BouncyCastle 1.79+) alongside existing Go/TS references

**README.md**
- Splits the browser demo bundle known limitation into an accurate description of committed snapshot vs CI-built copy
- Adds eighth known limitation: `interop_test.py` needs HTTP wrappers before Rust and Java can be included in the service-level interop test