### PR TITLE
fix: correct Mode 2 security claim — same properties as Mode 1 when fully verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ MTA-QR has three payload modes defined in the protocol. Modes 1 and 2 are implem
 
 **Mode 1 — cached checkpoint (offline after prefetch).** The payload includes the inclusion proof but not the checkpoint. The verifier resolves the checkpoint from its local cache; on cache miss it fetches once and caches the result. This is the default mode and the right choice for most deployments.
 
-**Mode 2 — online reference.** The payload contains only the log coordinates — no proof hashes. A scanner fetches the inclusion proof and checkpoint at scan time from a tile server. Smallest payload. Weaker tamper-evidence than Mode 1 (a compromised server can fabricate a proof). **The SDK verifier does not implement tile fetching** — it validates the checkpoint and TBS but skips the inclusion proof step. Use Mode 1 unless you are building your own tile-fetching scanner. See the Mode 2 limitation in Known Limitations.
+**Mode 2 — online reference.** The payload contains only the log coordinates — no proof hashes. A scanner fetches the checkpoint from the issuer's endpoint and the inclusion proof from a tile server at scan time. Smallest payload. The security properties of a correctly verified Mode 2 payload are identical to Mode 1 — the inclusion proof is cryptographically verifiable regardless of how it was delivered. The practical difference is operational: Mode 2 requires network access at scan time. **The SDK verifier does not implement tile fetching** — it validates the checkpoint and TBS but does not complete the inclusion proof step. Use Mode 1 when offline verification matters. See the Mode 2 limitation in Known Limitations.
 
 ### Mode 1 — inclusion proof embedded (48 cells)
 
@@ -127,7 +127,7 @@ The issuer computes and embeds a two-phase tiled Merkle proof at issuance time. 
 
 ### Mode 2 — proof deferred (48 cells)
 
-The issuer emits no proof hashes. In production a scanner fetches proof tiles from a tile server at scan time. The SDK verifier validates everything except inclusion (checkpoint, witnesses, TBS, expiry, `entry_index < tree_size`). See the Mode 2 limitation below.
+The issuer emits no proof hashes. In production a scanner fetches the checkpoint and inclusion proof at scan time and verifies them cryptographically — Mode 2 has the same security properties as Mode 1 when fully implemented. The reference SDK validates checkpoint, witnesses, TBS, and expiry but does not implement tile fetching. See the Mode 2 limitation below.
 
 | Issuer | Algorithm | Go | TS | Rust | Java |
 |--------|-----------|:--:|:--:|:----:|:----:|
@@ -180,7 +180,7 @@ Issuer.builder().origin("...").mode(2).signer(signer).build()
 
 The `VerifyOk`/`VerifyResult` returned by `verify()` includes a `mode` field so callers can distinguish the two cases.
 
-**Mode 2 limitation.** This SDK's verifier does **not** verify Merkle inclusion for Mode 2 payloads. It validates the checkpoint, witness cosignatures, TBS structure, expiry, and `entry_index < tree_size`, but returns a successful result without cryptographic proof that the entry is in the log. Building a complete Mode 2 scanner requires a tile server and tile-fetching logic on top of this library. Use Mode 1 if you need guaranteed inclusion proof at verify time.
+**Mode 2 tile fetching not implemented.** This SDK's verifier does **not** fetch or verify the inclusion proof for Mode 2 payloads. It validates the checkpoint, witness cosignatures, TBS structure, expiry, and `entry_index < tree_size`, then returns a result marked `mode=2`. The inclusion proof is cryptographically verifiable — when a complete Mode 2 scanner fetches the proof and checks it against the witnessed root, the security properties are identical to Mode 1. Building that scanner requires a tile-fetching implementation and a defined tile server API, neither of which exists yet. Use Mode 1 when you need inclusion proof verification today.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -877,16 +877,22 @@ packages. Any issuer whose verifiers have a charge cycle.
 ### Mode 2: Online Reference
 
 The QR payload contains only the assertion content and log coordinates.
-The verifier fetches the inclusion proof and checkpoint on demand.
+The verifier fetches the inclusion proof from a tile server and the checkpoint
+from the issuer's endpoint at scan time.
 
-Mode 2 provides weaker tamper-evidence guarantees than Modes 0 and 1. A
-compromised or MITM'd server can fabricate an inclusion proof at scan time.
-Mode 2 deployments MUST serve the inclusion proof endpoint over TLS with
-verifiable server identity. Mode 2 SHOULD NOT be used in deployments where
-tamper-evidence against a compromised infrastructure operator is a requirement.
+The security properties of a correctly verified Mode 2 payload are identical
+to Mode 1. The inclusion proof is cryptographically verifiable regardless of
+how it was delivered: any proof must lead to a root the witnesses have cosigned,
+and producing a valid proof for an entry that was never logged would require
+breaking SHA-256. The verifier checks the math either way.
+
+The practical difference from Mode 1 is operational: Mode 1 works offline
+after a prefetch; Mode 2 requires network access at scan time to fetch the
+checkpoint and inclusion proof. Mode 2 deployments MUST serve both endpoints
+over TLS with verifiable server identity.
 
 **Best for:** High-throughput fixed-infrastructure scanning where connectivity
-is guaranteed and the infrastructure operator is fully trusted.
+is guaranteed and the smallest possible payload size is a priority.
 
 ---
 
@@ -1085,8 +1091,9 @@ at scan time.
 complete Mode 2 verification algorithm for implementors building a production
 Mode 2 scanner. The reference SDK validates everything up to step 6 and then
 returns a result with `mode=2` without completing steps 7–8. Callers must
-check the `mode` field on the result and treat Mode 2 results as
-inclusion-unverified.
+check the `mode` field on the result and gate on it — a Mode 2 result from
+this SDK has not verified inclusion, because the tile fetch is not implemented,
+not because inclusion proof verification is inherently weaker in Mode 2.
 
 ```
 1.  Decode MTAQRPayload binary. Confirm proof_count == 0.
@@ -1117,11 +1124,16 @@ inclusion-unverified.
 9.  Decode entry_type_byte and act on claims.
 ```
 
-**Security note.** Steps 5–7 require network access at scan time and the
-server provides the proof. A compromised or MITM'd server can fabricate an
-inclusion proof. Mode 2 deployments MUST serve the tile endpoint over TLS with
-verifiable server identity. Mode 2 SHOULD NOT be used where tamper-evidence
-against a compromised infrastructure operator is a security requirement.
+**Security note.** Steps 5–7 require network access at scan time. The
+checkpoint (step 5) is verified against the trust configuration exactly as in
+Mode 1 — the issuer signature and witness cosignatures are checked
+cryptographically and cannot be fabricated. The inclusion proof (step 7) is
+also cryptographically verifiable: a valid proof must lead to the witnessed
+root hash, and constructing a false proof for an entry that was never logged
+would require breaking SHA-256. The security properties of a correctly
+completed Mode 2 verification are therefore identical to Mode 1. Mode 2
+deployments MUST serve both the checkpoint and tile endpoints over TLS with
+verifiable server identity to prevent MITM substitution of either.
 
 ---
 


### PR DESCRIPTION
Mode 2 was described as having weaker tamper-evidence than Mode 1. This is wrong. The inclusion proof is cryptographically verifiable regardless of delivery mechanism. The security properties are identical when fully verified. The only difference is operational: Mode 1 works offline, Mode 2 requires network at scan time.

Fixes SPEC.md (Mode 2 description, verification flow SDK note, verification flow security note) and README.md (modes description, interop matrix row, known limitations entry).