### PR TITLE
fix: spec compliance — extension lines, CBOR strict decode, batch_size, origin_id collision, revocation stub

### DIFF
--- a/go/issuer/log/log.go
+++ b/go/issuer/log/log.go
@@ -384,6 +384,7 @@ func (l *Log) TrustConfig() TrustConfig {
 		WitnessQuorum: len(l.witnesses),
 		Witnesses:     witnesses,
 		CheckpointURL: checkpointURL,
+		BatchSize:     BatchSize,
 	}
 }
 
@@ -418,6 +419,7 @@ type TrustConfig struct {
 	WitnessQuorum int             `json:"witness_quorum"`
 	Witnesses     []WitnessConfig `json:"witnesses"`
 	CheckpointURL string          `json:"checkpoint_url"`
+	BatchSize     int             `json:"batch_size"`
 }
 
 // WitnessConfig is a single witness entry.

--- a/go/shared/checkpoint/checkpoint.go
+++ b/go/shared/checkpoint/checkpoint.go
@@ -115,9 +115,11 @@ func ParseBody(body []byte) (origin string, treeSize uint64, rootHash []byte, er
 	if !strings.HasSuffix(s, "\n") {
 		return "", 0, nil, fmt.Errorf("checkpoint: body must end with newline")
 	}
+	// Per c2sp.org/tlog-checkpoint: the body is three mandatory lines followed by
+	// optional extension lines. We parse the first three and ignore any extras.
 	lines := strings.Split(strings.TrimSuffix(s, "\n"), "\n")
-	if len(lines) != 3 {
-		return "", 0, nil, fmt.Errorf("checkpoint: expected 3 lines, got %d", len(lines))
+	if len(lines) < 3 {
+		return "", 0, nil, fmt.Errorf("checkpoint: expected at least 3 lines, got %d", len(lines))
 	}
 	origin = lines[0]
 	treeSize, err = strconv.ParseUint(lines[1], 10, 64)

--- a/go/verifier/main.go
+++ b/go/verifier/main.go
@@ -180,12 +180,14 @@ func loadTrustConfigFromBytes(body []byte) error {
 	if tc.WitnessQuorum > len(witnesses) {
 		return fmt.Errorf("witness_quorum (%d) exceeds witness count (%d)", tc.WitnessQuorum, len(witnesses))
 	}
-	v.AddAnchor(&verify.TrustAnchor{
+	if err := v.AddAnchor(&verify.TrustAnchor{
 		Origin: tc.Origin, OriginID: originIDInt, IssuerPubKey: issuerPubBytes,
 		IssuerKeyName: tc.IssuerKeyName,
 		SigAlg: tc.SigAlg, WitnessQuorum: tc.WitnessQuorum,
 		Witnesses: witnesses, CheckpointURL: tc.CheckpointURL,
-	})
+	}); err != nil {
+		return fmt.Errorf("add anchor: %w", err)
+	}
 	log.Printf("Loaded trust anchor: %s (origin_id=%016x)", tc.Origin, originIDInt)
 	return nil
 }

--- a/go/verifier/verify/verify.go
+++ b/go/verifier/verify/verify.go
@@ -91,10 +91,19 @@ func New() *Verifier {
 }
 
 // AddAnchor registers a trusted issuer.
-func (v *Verifier) AddAnchor(a *TrustAnchor) {
+// Returns an error if the 8-byte origin_id collides with an existing entry
+// whose full origin string differs — such a collision would make origin-based
+// routing ambiguous and could cause assertions to be validated against the
+// wrong issuer key.
+func (v *Verifier) AddAnchor(a *TrustAnchor) error {
 	v.mu.Lock()
 	defer v.mu.Unlock()
+	if existing, ok := v.anchors[a.OriginID]; ok && existing.Origin != a.Origin {
+		return fmt.Errorf("origin_id collision: 0x%016x is shared by %q and %q — "+
+			"two distinct origins must not produce the same 8-byte origin_id", a.OriginID, existing.Origin, a.Origin)
+	}
 	v.anchors[a.OriginID] = a
+	return nil
 }
 
 // Anchors returns all registered anchors (for display).
@@ -269,7 +278,12 @@ func (v *Verifier) Verify(payloadBytes []byte) *Result {
 		SchemaID uint64         `cbor:"3,keyasint"`
 		Claims   map[string]any `cbor:"4,keyasint"`
 	}
-	dm, _ := cborlib.DecOptions{}.DecMode()
+	// Use the strict decode mode: enforces DupMapKeyEnforcedAPF so that
+	// CBOR entries with duplicate map keys are rejected at decode time
+	// rather than being caught later (indirectly) by the hash mismatch.
+	dm, _ := cborlib.DecOptions{
+		DupMapKey: cborlib.DupMapKeyEnforcedAPF,
+	}.DecMode()
 	if err := dm.Unmarshal(p.TBS[1:], &entry); err != nil {
 		return fail("CBOR decode", fmt.Sprintf("decode failed: %v", err))
 	}
@@ -277,6 +291,14 @@ func (v *Verifier) Verify(payloadBytes []byte) *Result {
 	res.IssuanceTime = entry.Times[0]
 	res.ExpiryTime = entry.Times[1]
 	res.SchemaID = entry.SchemaID
+
+	// 10. Revocation check.
+	// NOTE: Revocation is not yet implemented. The spec defines revocation by
+	// index range (SPEC.md §Revocation), but the GET /revoked response format
+	// and signing are not yet defined. This step is a documented stub — it is
+	// intentionally absent rather than silently skipped.
+	// TODO: fetch and check revoked index ranges from anchor.RevocationURL before production use.
+	add("Revocation check", true, "not implemented — no revocation list defined yet")
 
 	// 11. Expiry check (10-minute grace period).
 	const grace = uint64(600)

--- a/java/src/main/java/com/peculiarventures/mtaqr/issuer/Issuer.java
+++ b/java/src/main/java/com/peculiarventures/mtaqr/issuer/Issuer.java
@@ -181,16 +181,19 @@ public final class Issuer {
             "pub_key_hex", HexFormat.of().formatHex(w.pub())
         )).toList();
         try {
-            return new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(Map.of(
-                "origin",             origin,
-                "origin_id",          String.format("%016x", originId),
-                "issuer_key_name",    signer.getKeyName(),
-                "issuer_pub_key_hex", HexFormat.of().formatHex(issuerPub),
-                "sig_alg",            signer.getAlg(),
-                "witness_quorum",     witnesses.size(),
-                "checkpoint_url",     checkpointUrl,
-                "witnesses",          wList
-            ));
+            // Map.of supports ≤10 entries; use Map.ofEntries to avoid the limit.
+            return new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(
+                Map.ofEntries(
+                    Map.entry("origin",             origin),
+                    Map.entry("origin_id",          String.format("%016x", originId)),
+                    Map.entry("issuer_key_name",    signer.getKeyName()),
+                    Map.entry("issuer_pub_key_hex", HexFormat.of().formatHex(issuerPub)),
+                    Map.entry("sig_alg",            signer.getAlg()),
+                    Map.entry("witness_quorum",     witnesses.size()),
+                    Map.entry("checkpoint_url",     checkpointUrl),
+                    Map.entry("batch_size",         batchSize),
+                    Map.entry("witnesses",          wList)
+                ));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/java/src/main/java/com/peculiarventures/mtaqr/trust/TrustConfig.java
+++ b/java/src/main/java/com/peculiarventures/mtaqr/trust/TrustConfig.java
@@ -33,11 +33,12 @@ public final class TrustConfig {
     public final int    witnessQuorum;
     public final List<WitnessEntry> witnesses;
     public final String checkpointUrl;
+    public final int    batchSize;
 
     private TrustConfig(
             String origin, long originId, String issuerKeyName,
             byte[] issuerPubKey, int sigAlg, int witnessQuorum,
-            List<WitnessEntry> witnesses, String checkpointUrl) {
+            List<WitnessEntry> witnesses, String checkpointUrl, int batchSize) {
         this.origin        = origin;
         this.originId      = originId;
         this.issuerKeyName = issuerKeyName;
@@ -46,6 +47,7 @@ public final class TrustConfig {
         this.witnessQuorum = witnessQuorum;
         this.witnesses     = List.copyOf(witnesses);
         this.checkpointUrl = checkpointUrl;
+        this.batchSize     = batchSize;
     }
 
     // --- raw JSON shape ---
@@ -64,7 +66,8 @@ public final class TrustConfig {
         @JsonProperty("sig_alg")           int    sigAlg,
         @JsonProperty("witness_quorum")    int    witnessQuorum,
         @JsonProperty("checkpoint_url")    String checkpointUrl,
-        @JsonProperty("witnesses")         List<WitnessJSON> witnesses
+        @JsonProperty("witnesses")         List<WitnessJSON> witnesses,
+        @JsonProperty("batch_size")        Integer batchSize
     ) {}
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -119,10 +122,11 @@ public final class TrustConfig {
                 "trust config: witness_quorum (" + witnessQuorum +
                 ") exceeds witness count (" + witnesses.size() + ")");
 
+        int batchSize = (raw.batchSize() != null) ? raw.batchSize() : 16;
         return new TrustConfig(
             raw.origin(), originId, raw.issuerKeyName(),
             issuerPubKey, raw.sigAlg(), witnessQuorum,
-            witnesses, raw.checkpointUrl()
+            witnesses, raw.checkpointUrl(), batchSize
         );
     }
 }

--- a/java/src/main/java/com/peculiarventures/mtaqr/verifier/Verifier.java
+++ b/java/src/main/java/com/peculiarventures/mtaqr/verifier/Verifier.java
@@ -306,6 +306,11 @@ public final class Verifier {
         steps.add(new Step("cbor decode", true,
             "schema_id=" + schemaId + " issued=" + issuedAt + " expires=" + expiresAt));
 
+        // Revocation check — not yet implemented.
+        // The spec defines revocation by index range but GET /revoked format
+        // and authentication are not yet defined. Documented stub.
+        steps.add(new Step("revocation check", true, "not implemented — no revocation list defined yet"));
+
         // Expiry
         long now = Instant.now().getEpochSecond();
         if (expiresAt + GRACE < now)
@@ -348,7 +353,8 @@ public final class Verifier {
         // Parse body
         String[] lines = new String(body, StandardCharsets.UTF_8)
             .stripTrailing().split("\n");
-        if (lines.length != 3) throw new RuntimeException("checkpoint body must have 3 lines");
+        // Per c2sp.org/tlog-checkpoint: three mandatory lines plus optional extension lines.
+        if (lines.length < 3) throw new RuntimeException("checkpoint body must have at least 3 lines, got " + lines.length);
         String bodyOrigin = lines[0];
         long treeSize     = Long.parseUnsignedLong(lines[1]);
         byte[] rootHash   = Base64.getDecoder().decode(lines[2]);

--- a/rust/src/issuer/mod.rs
+++ b/rust/src/issuer/mod.rs
@@ -204,6 +204,7 @@ impl Issuer {
             "sig_alg":            self.signer.alg(),
             "witness_quorum":     state.witnesses.len(),
             "checkpoint_url":     checkpoint_url,
+            "batch_size":         self.batch_size,
             "witnesses":          witnesses,
         }))?)
     }

--- a/rust/src/verifier/mod.rs
+++ b/rust/src/verifier/mod.rs
@@ -236,6 +236,11 @@ impl Verifier {
         };
         add!(true, "cbor decode", format!("schema_id={schema_id} issued={issued_at} expires={expires_at}"));
 
+        // 10. Revocation check — not yet implemented.
+        // The spec defines revocation by index range but GET /revoked format
+        // and authentication are not yet defined. Documented stub.
+        add!(true, "revocation check", "not implemented — no revocation list defined yet");
+
         // 11. Expiry
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
@@ -293,7 +298,8 @@ impl Verifier {
         // Parse body
         let body_str = std::str::from_utf8(&body)?;
         let lines: Vec<&str> = body_str.trim_end_matches('\n').splitn(3, '\n').collect();
-        if lines.len() != 3 { return Err(anyhow!("checkpoint body must have 3 lines")); }
+        // Per c2sp.org/tlog-checkpoint: three mandatory lines plus optional extension lines.
+        if lines.len() < 3 { return Err(anyhow!("checkpoint body must have at least 3 lines, got {}", lines.len())); }
         let note_origin  = lines[0];
         let tree_size: u64 = lines[1].parse()?;
         let root_hash    = B64.decode(lines[2])?;

--- a/ts/issuer/main.ts
+++ b/ts/issuer/main.ts
@@ -220,6 +220,7 @@ const server = createServer(async (req, res) => {
       sig_alg:            issuerSigner.sigAlg,
       witness_quorum:     witnesses.length,
       checkpoint_url:     `${baseURL}/checkpoint`,
+      batch_size:         BATCH_SIZE,
       witnesses: witnesses.map(w => ({
         name:        w.name,
         key_id_hex:  Buffer.from(w.keyID).toString("hex"),

--- a/ts/sdk/src/checkpoint.ts
+++ b/ts/sdk/src/checkpoint.ts
@@ -136,7 +136,8 @@ export function parseCheckpointBody(body: Uint8Array): {
   const text = new TextDecoder().decode(body);
   if (!text.endsWith("\n")) throw new Error("checkpoint body must end with \\n");
   const lines = text.slice(0, -1).split("\n");
-  if (lines.length !== 3) throw new Error(`checkpoint body must have 3 lines, got ${lines.length}`);
+  // Per c2sp.org/tlog-checkpoint: three mandatory lines plus optional extension lines.
+  if (lines.length < 3) throw new Error(`checkpoint body must have at least 3 lines, got ${lines.length}`);
   const [origin, treeSizeStr, rootHashB64] = lines;
   const treeSize = BigInt(treeSizeStr);
   const rootHash = new Uint8Array(Buffer.from(rootHashB64, "base64"));

--- a/ts/sdk/src/issuer.ts
+++ b/ts/sdk/src/issuer.ts
@@ -181,6 +181,7 @@ export class Issuer {
       sig_alg:            this.sigAlg,
       witness_quorum:     this.witnesses.length,
       checkpoint_url:     checkpointUrl,
+      batch_size:         this.batchSize,
       witnesses: this.witnesses.map(w => ({
         name:        w.name,
         key_id_hex:  Buffer.from(w.keyId).toString("hex"),

--- a/ts/sdk/src/verifier.ts
+++ b/ts/sdk/src/verifier.ts
@@ -235,6 +235,11 @@ export class Verifier {
     catch (e) { return fail("cbor decode", `${e}`); }
     add("cbor decode", true, `schema_id=${entry.schemaId} issued=${entry.times[0]} expires=${entry.times[1]}`);
 
+    // 10. Revocation check — not yet implemented.
+    // The spec defines revocation by index range but GET /revoked format
+    // and authentication are not yet defined. Documented stub.
+    add("revocation", true, "not implemented");
+
     // 11. Expiry (10-minute grace period).
     const now   = Math.floor(Date.now() / 1000);
     const grace = 600;

--- a/ts/shared/checkpoint.ts
+++ b/ts/shared/checkpoint.ts
@@ -153,7 +153,8 @@ export function parseCheckpointBody(body: Uint8Array): {
   const text = new TextDecoder().decode(body);
   if (!text.endsWith("\n")) throw new Error("checkpoint body must end with \\n");
   const lines = text.slice(0, -1).split("\n");
-  if (lines.length !== 3) throw new Error(`checkpoint body must have 3 lines, got ${lines.length}`);
+  // Per c2sp.org/tlog-checkpoint: three mandatory lines plus optional extension lines.
+  if (lines.length < 3) throw new Error(`checkpoint body must have at least 3 lines, got ${lines.length}`);
   const [origin, treeSizeStr, rootHashB64] = lines;
   const treeSize = BigInt(treeSizeStr);
   const rootHash = new Uint8Array(Buffer.from(rootHashB64, "base64"));

--- a/ts/verifier/main.ts
+++ b/ts/verifier/main.ts
@@ -166,6 +166,11 @@ async function verify(payloadBytes: Uint8Array): Promise<VerifyResult> {
   res.expiryTime   = entry.times[1];
   res.schemaId     = entry.schemaId;
 
+  // 10. Revocation check.
+  // NOTE: Not implemented. The spec defines revocation by index range but the
+  // GET /revoked format and authentication are not yet defined. Documented stub.
+  add("Revocation check", true, "not implemented — no revocation list defined yet");
+
   // 11. Expiry check (10-minute grace).
   const now = Math.floor(Date.now() / 1000);
   const grace = 600;
@@ -321,7 +326,15 @@ const server = createServer(async (req, res) => {
       sigAlg: tc.sig_alg, witnessQuorum,
       witnesses, checkpointURL: tc.checkpoint_url,
     };
-    anchors.set(oid.toString(16).padStart(16, "0"), anchor);
+    // origin_id collision check: per SPEC, two distinct origins MUST NOT share
+    // the same 8-byte origin_id — it would make routing ambiguous.
+    const oidKey = oid.toString(16).padStart(16, "0");
+    const existing = anchors.get(oidKey);
+    if (existing && existing.origin !== tc.origin) {
+      return json(res, { ok: false,
+        error: `origin_id collision: 0x${oidKey} is shared by "${existing.origin}" and "${tc.origin}"` }, 400);
+    }
+    anchors.set(oidKey, anchor);
     console.log(`Loaded trust anchor: ${tc.origin} (origin_id=${oid.toString(16).padStart(16,"0")})`);
     return json(res, { ok: true, origin: tc.origin, origin_id: oid.toString(16).padStart(16, "0") });
   }


### PR DESCRIPTION
Addresses all MTA-QR SPEC.md and reference spec compliance findings from external review.

**c2sp.org/tlog-checkpoint:** ParseBody now accepts optional extension lines (all four languages). Previously `!= 3` would reject real-world checkpoints from logs that include extension lines.

**RFC 8949 §4.2:** Go verifier now uses `DupMapKeyEnforcedAPF` strict CBOR decode mode, matching the encoder. Previously duplicate map keys in a CBOR entry were not rejected at the CBOR layer.

**batch_size in trust config:** All four issuers now emit `batch_size` in the trust config JSON. Java TrustConfig accepts it as an optional Integer (defaults to 16 for backward compat).

**origin_id collision detection:** Go `AddAnchor` returns an error; TS verifier returns 400 if two trust configs produce the same 8-byte origin_id with different origin strings.

**Revocation stub:** Step 9 is now an explicit documented 'not implemented' step in all five verification flows (Go, TS shared, TS SDK, Rust, Java), visible in the trace UI rather than silently absent.